### PR TITLE
Abstract domain

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+CF_DNS_API_TOKEN=<cloudflare api token, Zone/DNS/Edit permissions>
+CF_API_EMAIL=<letsencrypt account email>

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ target/
 /main-*
 
 acme.json
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,4 @@
-FROM letfn/python
-
-COPY --chown=app:app requirements.txt /app/src/
-RUN . /app/venv/bin/activate && pip install --no-cache-dir -r /app/src/requirements.txt
-
-COPY service /service
-
-ENTRYPOINT [ "/tini", "--", "/service" ]
+FROM alpine:edge
+RUN apk --no-cache add dnsmasq
+EXPOSE 53 53/udp
+ENTRYPOINT ["dnsmasq", "--no-hosts", "--no-resolv", "--log-queries", "--keep-in-foreground", "-d"]

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -4,19 +4,19 @@ services:
   traefik:
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.traefik-api.rule=Host(`traefik.whoa.bot`) && PathPrefix(`/api`)"
+      - "traefik.http.routers.traefik-api.rule=Host(`traefik.${KITT_DOMAIN}`) && PathPrefix(`/api`)"
       - "traefik.http.routers.traefik-api.service=api@internal"
-      - "traefik.http.routers.traefik-dash.rule=Host(`traefik.whoa.bot`)"
+      - "traefik.http.routers.traefik-dash.rule=Host(`traefik.${KITT_DOMAIN}`)"
       - "traefik.http.routers.traefik-dash.service=dashboard@internal"
   consul:
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.consul.rule=Host(`consul.whoa.bot`)"
+      - "traefik.http.routers.consul.rule=Host(`consul.${KITT_DOMAIN}`)"
       - "traefik.http.services.consul.loadbalancer.server.port=8500"
   portainer:
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.portainer.rule=Host(`portainer.whoa.bot`)"
+      - "traefik.http.routers.portainer.rule=Host(`portainer.${KITT_DOMAIN}`)"
       - "traefik.http.services.portainer.loadbalancer.server.port=9000"
 
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,3 +50,11 @@ services:
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
       - "./etc/data/portainer:/data"
+  dnsmasq:
+    build: .
+    cap_add:
+      - NET_ADMIN
+    command: --address=/${KITT_DOMAIN}/169.254.32.1
+    ports:
+      - 169.254.32.1:53:53/tcp
+      - 169.254.32.1:53:53/udp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3.7'
 services:
   traefik:
     image: "traefik:v2.2.1"
+    env_file: .env
     command:
       - --providers.docker
       - --providers.docker.usebindportip
@@ -16,8 +17,12 @@ services:
       - --entrypoints.http.proxyprotocol.insecure
       - --entrypoints.http.http.redirections.entryPoint.to=https
       - --entrypoints.http.http.redirections.entryPoint.scheme=https
-      - --certificatesResolvers.le.acme.email=le@example.com
-      - --certificatesResolvers.le.acme.storage=/etc/traefik/acme/acme.json
+      - --certificatesResolvers.le.acme.email=${CF_API_EMAIL}
+      - --certificatesResolvers.le.acme.storage=/etc/traefik/conf.d/acme.json
+      - --certificatesResolvers.le.acme.dnschallenge=true
+      - --certificatesResolvers.le.acme.dnschallenge.provider=cloudflare
+      - --certificatesResolvers.le.acme.dnschallenge.delaybeforecheck=0
+      - --certificatesResolvers.le.acme.dnschallenge.resolvers=1.1.1.1
       - --entrypoints.https.address=:443
       - --entrypoints.https.proxyprotocol.insecure
       - --entrypoints.https.http.tls.certResolver=le
@@ -27,7 +32,7 @@ services:
       - --api
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
-      - "./etc:/etc/traefik"
+      - "./etc/conf.d:/etc/traefik/conf.d"
     ports:
       - "2222:22"
       - 80:80

--- a/etc/dns/systemd-resolved/kitt_domain.conf
+++ b/etc/dns/systemd-resolved/kitt_domain.conf
@@ -1,0 +1,3 @@
+[Resolve]
+DNS=169.254.32.1
+Domains=KITT_DOMAIN


### PR DESCRIPTION
KITT_DOMAIN env var set by user. corresponds to their cloudwatch domain. I set this var in my ~/.bashrc

add dnsmasq container to dynamically add cloudwatch root domain & wildcard domain to local host. domain resolves to dummy0 ip.

this pr includes additions to make linux and make linux-down Makefile targets for setting up and tearing down local host split dns for cloudwatch domain. only support for linux hosts that use systemd-resolved to manage dns.

plus add config to traefik to enable letsencrypt dns challenge to generate acme ssl certs