### PR TITLE
dont need to bundle hera with kitt

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,11 +33,6 @@ services:
       - 80:80
       - 443:443
       - 1194:1194
-  hera:
-    image: aschzero/hera:latest
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-      - ${HOME}/.cloudflared:/certs
   cloudflared:
     image: letfn/cloudflared
     restart: always


### PR DESCRIPTION
Hera can be run separately.  The cloudflared tunnel that pairs with traefik can handle multiple sub domains.