### PR TITLE
cloudflared depends_on traefik

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,6 +79,7 @@ services:
       - TUNNEL_URL=https://${KITT_TUNNEL_URL}
       - TUNNEL_HOSTNAME=${KITT_TUNNEL_HOSTNAME}
     depends_on:
+      - traefik
       - consul
   zerotier:
     image: letfn/zerotier


### PR DESCRIPTION
seems to help acme ssl cert generation if cloudflared waits for traefik to load before starting (otherwise cloudflared exits prematurely)