### PR TITLE
traefik 2.2.5 and no wildcards by default

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -41,12 +41,12 @@ steps:
 - name: kaniko
   image: letfn/drone-kaniko
   settings:
-    args: --destination=defn/kitt
+    args: --destination=registry.defn.sh/defn/kitt
     cache: true
-    cache_repo: defn/cache
+    cache_repo: registry.defn.sh/defn/cache
     password:
       from_secret: docker_password
-    repo: defn/kitt
+    repo: registry.defn.sh/defn/kitt
     tag: latest
     username:
       from_secret: docker_username

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -3,7 +3,5 @@ version: '3.7'
 services:
   traefik:
     labels:
-      - "traefik.http.routers.domains.tls=true"
-      - "traefik.http.routers.domains.tls.certresolver=le"
-      - "traefik.http.routers.domains.tls.domains[0].main=your.domain"
-      - "traefik.http.routers.domains.tls.domains[0].sans=*.your.domain"
+      - "traefik.http.routers.domains.tls.domains[1].main=${KITT_DOMAIN}"
+      - "traefik.http.routers.domains.tls.domains[1].sans=*.${KITT_DOMAIN}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
     depends_on:
       - consul
     ports:
-      - ${KITT_IP}:22:22
+      - ${KITT_IP}:2222:22
       - ${KITT_IP}:80:80
       - ${KITT_IP}:443:443
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   traefik:
-    image: "traefik:v2.2.1"
+    image: "traefik:v2.2.5"
     command:
       - --providers.docker=true
       - --providers.docker.exposedbydefault=false
@@ -23,7 +23,7 @@ services:
       - --certificatesResolvers.le.acme.dnschallenge=true
       - --certificatesResolvers.le.acme.dnsChallenge.provider=cloudflare
       - --certificatesResolvers.le.acme.email=${CF_API_EMAIL}
-      - --certificatesResolvers.le.acme.storage=/etc/traefik/acme/acme.json
+      - --certificatesResolvers.le.acme.storage=${KITT_ACME_STORAGE:-/etc/traefik/acme/acme.json}
       - --certificatesResolvers.le.acme.dnschallenge.delaybeforecheck=0
       - --certificatesResolvers.le.acme.dnschallenge.resolvers=1.1.1.1
       - --entrypoints.https.address=:443
@@ -54,6 +54,10 @@ services:
       - "traefik.http.routers.traefik-dash.entrypoints=http,https"
       - "traefik.http.routers.traefik-dash.rule=HostRegexp(`traefik{domain:.+}`)"
       - "traefik.http.routers.traefik-dash.service=dashboard@internal"
+      - "traefik.http.routers.domains.tls=true"
+      - "traefik.http.routers.domains.tls.certresolver=le"
+      - "traefik.http.routers.domains.tls.domains[0].main=traefik-kitt.${KITT_DOMAIN}"
+      - "traefik.http.routers.domains.tls.domains[0].sans=vault.${KITT_DOMAIN},consul.${KITT_DOMAIN}"
   traefik-proxy:
     image: letfn/consul-envoy:v1.8.0-v1.14.2
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - --serverstransport.insecureskipverify=true
       - --log.level=DEBUG
       - --accesslog=true
-      - --entrypoints.ssh.address=:22
+      - --entrypoints.ssh.address=:2222
       - --entrypoints.http.address=:80
       - --entrypoints.http.proxyprotocol.insecure
       - --entrypoints.http.http.redirections.entryPoint.to=https
@@ -42,7 +42,7 @@ services:
     depends_on:
       - consul
     ports:
-      - ${KITT_IP}:2222:22
+      - ${KITT_IP}:2222:2222
       - ${KITT_IP}:80:80
       - ${KITT_IP}:443:443
     labels:


### PR DESCRIPTION
- traefik 2.2.5 to get acme fixes for parallel requests
- no wildcards requested, only: traefik-kitt, consul, and vault for a minimum working kitt
- example for adding wildcard and base domain certs in overrides
- introducing support for KITT_ACME_STORAGE for storing certs into k/v like consul
- listen on port 2222 since 22 conflicts on Linux systems